### PR TITLE
🔧 Fixed issue with aiohttp version

### DIFF
--- a/nekosbest/__init__.py
+++ b/nekosbest/__init__.py
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-__version__ = "1.1.11"
+__version__ = "1.1.12"
 __author__ = "PredaaA"
 __copyright__ = "Copyright 2021-present PredaaA"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Internet
     Topic :: Software Development :: Libraries
     Topic :: Software Development :: Libraries :: Python Modules
@@ -32,7 +33,7 @@ include_package_data = False
 packages = find_namespace:
 python_requires = >=3.8
 install_requires =
-    aiohttp>=3.6.2,<3.8.1
+    aiohttp>=3.6.2
 
 [options.packages.find]
 include =


### PR DESCRIPTION
When installing `aiogram` together with `nekosbest`, there were discrepancies between the necessary versions of `aiohttp`.
So I fixed it by removing the max version of the package

```diff
@@ -32,7 +33,7 @@ include_package_data = False
  packages = find_namespace:
  python_requires = >=3.8
  install_requires =
-     aiohttp>=3.6.2,<3.8.1
+     aiohttp>=3.6.2
```

