### PR TITLE
aiohttp session pooling, minor fixes and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,28 @@ loop.run_until_complete(get_img("nekos", 2))
 
 ```
 
+The previous example may yield a warning because we didn't close the client session explicitly.
+
+Here is the recommended usage:
+
+```py
+import asyncio
+from nekosbest import Client
+
+async def main():
+    async with Client() as client:
+        # Get a single nyan
+        single_result = await client.get_image("nekos")
+        print(single_result)
+        
+        # Get two nyans
+        multi_result = await client.get_image("nekos", 2)
+        print(multi_result)
+
+asyncio.run(main())
+```
+
+
 ## Breaking changes
 
 ### Migrate from 0.x.x to 1.0.0

--- a/nekosbest/__init__.py
+++ b/nekosbest/__init__.py
@@ -21,10 +21,8 @@ __author__ = "PredaaA"
 __copyright__ = "Copyright 2021-present PredaaA"
 
 
-from .client import Client as Client
-from .errors import (
-    APIError as APIError,
-    NekosBestBaseError as NekosBestBaseError,
-    NotFound as NotFound,
-)
-from .models import Result as Result
+from .client import Client
+from .errors import APIError, NekosBestBaseError, NotFound
+from .models import Result
+
+__all__ = ("Client", "APIError", "NekosBestBaseError", "NotFound", "Result")

--- a/nekosbest/client.py
+++ b/nekosbest/client.py
@@ -28,7 +28,16 @@ class Client:
     def __init__(self):
         self.http = HttpClient()
 
-    async def get_image(self, category: str, amount: int = 1) -> List[Result]:
+    async def close(self):
+        await self.http.close()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.close()
+
+    async def get_image(self, category: str, amount: int = 1) -> Union[Result, List[Result]]:
         """
         |coro|
 

--- a/nekosbest/errors.py
+++ b/nekosbest/errors.py
@@ -26,10 +26,11 @@ class NotFound(NekosBestBaseError):
 
 
 class APIError(NekosBestBaseError):
-    """Raised when API returns an unexcepted status code."""
+    """Raised when API returns an unexpected status code."""
 
     def __init__(self, code: int = None):
         self.code = code
+        super().__init__(f"API returned an unexpected status code: {code}")
 
 
 class ClientError(NekosBestBaseError):

--- a/nekosbest/http.py
+++ b/nekosbest/http.py
@@ -18,7 +18,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import annotations
 
-import platform
+import sys
 from typing import TYPE_CHECKING
 
 import aiohttp
@@ -31,24 +31,42 @@ if TYPE_CHECKING:
     from .types import ResultType
 
 
+
 class HttpClient:
     BASE_URL = "https://nekos.best/api/v2"
+
+    # Old implementation used to truncate 3.14 to 3.1
+    _platform_python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+
     DEFAULT_HEADERS = {
-        "User-Agent": f"nekosbest.py v{__version__} (Python/{(platform.python_version())[:3]} aiohttp/{aiohttp.__version__})"
+        "User-Agent": f"nekosbest.py v{__version__} (Python/{_platform_python_version} aiohttp/{aiohttp.__version__})"
     }
 
+    def __init__(self):
+        # Connection pooling
+        self.session = None
+
+    async def close(self):
+        if self.session and not self.session.closed:
+            await self.session.close()
+
     async def get(self, endpoint: str, amount: int, **kwargs) -> ResultType:
+
+        if self.session is None or self.session.closed:
+            self.session = aiohttp.ClientSession()
+
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(
-                    f"{self.BASE_URL}/{endpoint}",
-                    params={"amount": amount} if amount > 1 else {},
-                    headers=self.DEFAULT_HEADERS,
-                ) as resp:
-                    if resp.status == 404:
-                        raise NotFound()
-                    if resp.status != 200:
-                        raise APIError(resp.status)
-                    return await resp.json(content_type=None)
-        except aiohttp.ClientConnectionError:
-            raise ClientError()
+            async with self.session.get(
+                f"{self.BASE_URL}/{endpoint}",
+                params={"amount": amount} if amount > 1 else {},
+                headers=self.DEFAULT_HEADERS,
+            ) as resp:
+                if resp.status == 404:
+                    raise NotFound()
+                if resp.status != 200:
+                    raise APIError(resp.status)
+                return await resp.json(content_type=None)
+
+        # Context
+        except aiohttp.ClientConnectionError as exc:
+            raise ClientError("Failed to connect to API.") from exc


### PR DESCRIPTION
This PR is an attempt to improve the wrapper, it...

- Utilizes connection pooling in `HttpClient`, per recommended use for `aiohttp`
- Gracefully handles the `Client` session when paired with `async`
- Gives clear API code errors
- Offers better traceback via `from`
- MAkes a minor cleanup of `__init__.py` via `__all__`